### PR TITLE
Fix absence of dotfills for the section in ToC

### DIFF
--- a/sty/table-of-contents.sty
+++ b/sty/table-of-contents.sty
@@ -30,6 +30,10 @@
 % section line spacing
 \setlength{\cftbeforesecskip}{3pt}
 
+% for some reason, section does not have a dotfill by default, so, explicitly
+% add it here
+\renewcommand{\cftsecleader}{\cftdotfill{\cftdotsep}}
+
 % spacing
 \renewcommand\cftdotsep{1}
 


### PR DESCRIPTION
This PR fixes a table of contents formatting by adding dots to the section.

Before this fix:
<img width="1051" alt="Screenshot 2020-01-23 at 11 14 28" src="https://user-images.githubusercontent.com/8746283/72967302-1ac89180-3dd2-11ea-9520-ce5905a5fa82.png">

After this fix:
<img width="1053" alt="Screenshot 2020-01-23 at 11 14 14" src="https://user-images.githubusercontent.com/8746283/72967306-1c925500-3dd2-11ea-9805-1df19b0346aa.png">
